### PR TITLE
Fix GH repositories link in Projects page

### DIFF
--- a/src/ui/projects/Projects.html
+++ b/src/ui/projects/Projects.html
@@ -41,7 +41,7 @@
     <project-cmp
       name="more ..."
       description="You can find more at my GitHub profile"
-      url="https://github.com/hawkgs/repositories">
+      url="https://github.com/hawkgs?tab=repositories">
       <svg-loader path="projects/shared/icons/more"></svg-loader>
     </project-cmp>
   </div>


### PR DESCRIPTION
correct url for your repositories page in github from https://github.com/hawkgs/repositories to https://github.com/hawkgs?tab=repositories. Please review and update. Thank You.